### PR TITLE
notify clients when publisher stopped broadcasting 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -90,6 +90,7 @@ echo Creating stream $STREAM_NAME
 cat >>${NGINX_CONFIG_FILE} <<!EOF
         application ${STREAM_NAME} {
             live on;
+            publish_notify on;
             record off;
             on_publish http://localhost:8080/on_publish;
 !EOF


### PR DESCRIPTION
In my use case I'm using ngnix-rtmp as rtmp proxy.
When rtmp publisher disconnects, ffmpeg rtmp subscribers hangs indefinitely, and manually closing ffmpeg causes file corruption.
This pull request resolves this issue by notifying client on publish/unpublish and handle it accordingly so ffmpeg exits gracefully.